### PR TITLE
use affine-warped template seg of cortical targets

### DIFF
--- a/diffparc/workflow/rules/surftrack.smk
+++ b/diffparc/workflow/rules/surftrack.smk
@@ -175,7 +175,7 @@ def get_dseg_targets(wildcards):
                 **subj_wildcards,
                 space="individual",
                 desc="{targets}",
-                from_="synthseg",
+                from_="synthsegnearest",
                 datatype="anat",
                 suffix="dseg.mif"
             ),


### PR DESCRIPTION
- masked with synthseg cortex
- hack fix for allowing template-based labelling, but with tissue segmentation accuracy of synthseg..
- uses signed distance transform to map nearest template label
- NOTE: nonlinear warp would be more precise..