### PR TITLE
option to use synthseg for seed and targets separately

### DIFF
--- a/diffparc/config/snakebids.yml
+++ b/diffparc/config/snakebids.yml
@@ -428,4 +428,7 @@ slspec_txt: False
 eddy_no_s2v: True
 
 use_topup: False
-use_synthseg: True
+use_synthseg_seed: True
+use_synthseg_targets: False
+
+

--- a/diffparc/workflow/rules/surfmorph.smk
+++ b/diffparc/workflow/rules/surfmorph.smk
@@ -56,7 +56,7 @@ rule set_surface_structure:
 
 
 def get_subject_seg_for_shapereg(wildcards):
-    if config["use_synthseg"]:
+    if config["use_synthseg_seed"]:
         return (
             bids(
                 root=root,

--- a/diffparc/workflow/rules/surftrack.smk
+++ b/diffparc/workflow/rules/surftrack.smk
@@ -168,7 +168,7 @@ rule track_from_vertices:
 
 def get_dseg_targets(wildcards):
 
-    if config["use_synthseg"]:
+    if config["use_synthseg_targets"]:
         return (
             bids(
                 root=root,
@@ -197,7 +197,7 @@ def get_dseg_targets(wildcards):
 
 def get_dseg_targets_nii(wildcards):
 
-    if config["use_synthseg"]:
+    if config["use_synthseg_targets"]:
         return (
             bids(
                 root=root,


### PR DESCRIPTION
- split up the use_synthseg config option to act on (cortical) targets and (subcortical) seed separately.. 
- by default we won't use synthseg for targets, and use the legacy atlas-based method (so we have the flexibility of customizing the label map)
- for seeds, synthseg is still used alongside template injection.. 