### PR TITLE
set root dir for qc outputs, with qc datatype dir

### DIFF
--- a/diffparc/workflow/Snakefile
+++ b/diffparc/workflow/Snakefile
@@ -342,12 +342,15 @@ def get_synthseg_subj_tables_legacy():
 
 def get_subj_qc():
     qc_snaps = []
+    if config["volume_metrics"] == None or config["surface_metrics"] == None:
+        return []
     for seed in config["select_seeds"]:
         qc_snaps.extend(
             expand(
                 expand(
                     bids(
-                        root="qc",
+                        root=root,
+                        datatype="qc",
                         desc="{targets}",
                         method="{method}",
                         seedspervertex="{seedspervertex}",

--- a/diffparc/workflow/rules/visqc.smk
+++ b/diffparc/workflow/rules/visqc.smk
@@ -161,7 +161,8 @@ rule qc_structure:
     output:
         png=report(
             bids(
-                root="qc",
+                root=root,
+                datatype="qc",
                 desc="{targets}",
                 method="{method}",
                 seedspervertex="{seedspervertex}",
@@ -199,7 +200,8 @@ rule qc_synthseg:
     output:
         png=report(
             bids(
-                root="qc",
+                root=root,
+                datatype="qc",
                 subject="{subject}",
                 session="{session}",
                 desc="synthseg",


### PR DESCRIPTION
Moves qc outputs to subject folder (with datatype="qc") instead of setting the root folder to "qc". Could consider moving it back at some point, but this makes it compatible with batch-diffparc-surf for the time being (as the root qc folder would not be copied after the run).