### PR TITLE
fix: run surf gen in shadow directory

### DIFF
--- a/diffparc/workflow/rules/surfgen.smk
+++ b/diffparc/workflow/rules/surfgen.smk
@@ -40,6 +40,8 @@ rule gen_template_surface:
         ),
     group:
         "subj"
+    shadow:
+        "minimal"
     container:
         config["singularity"]["diffparc"]
     script:


### PR DESCRIPTION
was causing bugs when pyvista was writing to a .local folder in multiple rules