### PR TITLE
[WIP] Update group target

### DIFF
--- a/diffparc/config/snakebids.yml
+++ b/diffparc/config/snakebids.yml
@@ -24,7 +24,7 @@ targets_by_analysis_level:
   participant:
     - ''  # if '', then the first rule is run
   group:
-    - 'all_legacy_csv'
+    - 'group_csv'
 
 pybids_inputs:
   dwi:

--- a/diffparc/workflow/Snakefile
+++ b/diffparc/workflow/Snakefile
@@ -478,6 +478,72 @@ def get_subj_qc():
     return qc_snaps
 
 
+def get_group_tables():
+    csvs = []
+
+    for seed in config["select_seeds"]:
+        # dti measures (currently only mrtrix)
+        csvs.extend(
+            expand(
+                bids(
+                    root=root,
+                    subject="group",
+                    datatype="tabular",
+                    label="{seed}",
+                    desc="{targets}",
+                    seedspervertex="{seedspervertex}",
+                    method="{method}",
+                    suffix="{suffix}.csv",
+                ),
+                seed=seed,
+                targets=config["seeds"][seed]["targets"],
+                seedspervertex=config["seeds"][seed]["seeds_per_vertex"],
+                method=config["methods"],
+                suffix=list(
+                    set(config["surface_metrics"]).difference(
+                        {"bundleFA", "bundleMD", "surfvol", "surfvolmni"}
+                    )
+                ),
+            ),
+        )
+        # dseg dti measures
+        csvs.extend(
+            expand(
+                bids(
+                    root=root,
+                    subject="group",
+                    datatype="tabular",
+                    method="{dseg_method}",
+                    suffix="{metric}.csv",
+                ),
+                dseg_method=config["aux_dseg"].keys(),
+                metric=list(
+                    set(config["aux_metrics"]).difference({"vol", "volmni"}),
+                ),
+            ),
+        )
+        # surface-based (enclosed) volume metrics (not parcellated)
+        csvs.extend(
+            expand(
+                bids(
+                    root=root,
+                    subject="group",
+                    datatype="tabular",
+                    method="{method}",
+                    suffix="{suffix}.csv",
+                ),
+                method=config["methods"],
+                suffix=list(
+                    set(config["surface_metrics"]).intersection(
+                        {"surfvol", "surfvolmni"}
+                    )
+                ),
+            ),
+        )
+
+    return csvs
+
+
 rule all:
     input:
         get_subj_spec(),
@@ -488,6 +554,23 @@ rule all:
         get_subj_vbm(),
         get_subj_dti_vbm(),
     default_target: True
+
+
+rule group_csv:
+    input:
+        get_group_tables(),
+    output:
+        combined_csv=bids(
+            root=root,
+            subject="group",
+            datatype="tabular",
+            desc="combined",
+            suffix="metrics.csv",
+        ),
+    container:
+        config["singularity"]["diffparc"]
+    script:
+        "scripts/combine_group_csv.py"
 
 
 include: "rules/common.smk"

--- a/diffparc/workflow/rules/tables.smk
+++ b/diffparc/workflow/rules/tables.smk
@@ -393,7 +393,7 @@ rule write_surf_volumes_mni_csv:
         "../scripts/write_surface_volume_metric.py"
 
 
-rule concat_subj_csv:
+rule concat_subj_dti_csv:
     input:
         csvs=expand(
             bids(
@@ -402,12 +402,13 @@ rule concat_subj_csv:
                 desc="{targets}",
                 label="{seed}",
                 seedspervertex="{seedspervertex}",
+                method="{method}",
                 suffix="{suffix}.csv",
-                **subj_wildcards
+                **subj_wildcards,
             ),
             zip,
             **subj_zip_list,
-            allow_missing=True
+            allow_missing=True,
         ),
         #loop over subjects and sessions 
     output:
@@ -415,10 +416,41 @@ rule concat_subj_csv:
             root=root,
             subject="group",
             datatype="tabular",
-            desc="{targets}",
             label="{seed}",
+            desc="{targets}",
             seedspervertex="{seedspervertex}",
+            method="{method}",
             suffix="{suffix}.csv",
+        ),
+    container:
+        config["singularity"]["diffparc"]
+    group:
+        "agg"
+    script:
+        "../scripts/concat_csv.py"
+
+
+rule concat_subj_dseg_dtimetrics_csv:
+    input:
+        csvs=expand(
+            bids(
+                root=root,
+                datatype="tabular",
+                method="{dseg_method}",
+                suffix="{metric}.csv",
+                **subj_wildcards,
+            ),
+            zip,
+            **subj_zip_list,
+            allow_missing=True,
+        ),
+    output:
+        csv=bids(
+            root=root,
+            subject="group",
+            datatype="tabular",
+            method="{dseg_method}",
+            suffix="{metric}.csv",
         ),
     container:
         config["singularity"]["diffparc"]

--- a/diffparc/workflow/scripts/combine_group_csv.py
+++ b/diffparc/workflow/scripts/combine_group_csv.py
@@ -1,0 +1,37 @@
+import pandas as pd
+
+from glob import iglob
+from pathlib import Path
+
+csv_fpaths = str(Path(snakemake.output.combined_csv).parent / "*")
+
+for idx, csv_fpath in enumerate(iglob(csv_fpaths)):
+    col_suffix = csv_fpath.split("/")[-1].split("_")  # Split fname by comp.
+    col_suffix[-1] = col_suffix[-1].split(".")[0]  # Remove extension
+
+    # Filter through list to keep only label, method, and metric
+    col_suffix = [
+        comp
+        for comp in col_suffix
+        if not (
+            comp.startswith("sub")
+            or comp.startswith("seedspervertex")
+            or comp.startswith("desc")
+        )
+    ]
+    col_suffix = "_".join(comp for comp in col_suffix)
+
+    tmp_df = pd.read_csv(csv_fpath)
+    tmp_df.rename(
+        columns=lambda col: f"{col}_{col_suffix}"
+        if col.lower() not in ["subj"]
+        else col,
+        inplace=True,
+    )
+
+    if idx == 0:
+        combined_df = tmp_df.copy()
+    else:
+        combined_df = pd.merge(left=combined_df, right=tmp_df, how="outer", on="subj")
+
+    combined_df.to_csv(snakemake.output.combined_csv, index=False)


### PR DESCRIPTION
This (_WIP_) PR updates the workflow to make use of the `concat_subj_csv` rule in `tables.smk`, updating the expected input and output files, as well as update the target group rule by adding a `get_group_tables()` function to create a concatenated, metric-specific table. Additionally, a python script is run at the target rule to combine the concatenated tables into a single, combined table.

The one issue currently is if the `group` target rule is run without first running the workflow again with `--touch`, it will rerun rules within the workflow again trying to update the input files. This only occurs if the workflow is submitted to the slurm scheduler - was not needed in interactive testing of the workflow.