### PR TITLE
fix typo in config for msmt_csd fod option

### DIFF
--- a/diffparc/config/snakebids.yml
+++ b/diffparc/config/snakebids.yml
@@ -165,7 +165,7 @@ parse_args:
     nargs: '?'
     choices: 
       - 'csd'
-      - 'msmt_csd '
+      - 'msmt_csd'
     default: 'csd'
 
   --stat_along_tcks:


### PR DESCRIPTION
had an extra space, which prevented the msmt_csd option from being used..

